### PR TITLE
curl, mercurial specified only if not already defined

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,7 +29,13 @@ class golang (
     path => "/usr/local/go/bin:/usr/local/bin:/usr/bin:/bin",
   }
 
-  package { ["curl", "mercurial"]: }
+  if ! defined(Package['curl']) {
+    package { "curl": }
+  }
+
+  if ! defined(Package['mercurial']) {
+    package { "mercurial": }
+  }
 
   exec { "download":
     command => "curl -o $download_dir/go-$version.tar.gz $download_location",


### PR DESCRIPTION
This PR wraps `! defined` around the mercerial, curl package this doesn't conflict with previous declarations of these packages.

Let me know what you think, if I need to modify anything to get it up, and/or you have a better way to do this.

Thanks!
