### PR TITLE
download_location uses 'arch' parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,7 +22,7 @@ class golang (
   if ($download_url) {
     $download_location = $download_url
   } else {
-    $download_location = "https://storage.googleapis.com/golang/go${version}.linux-${architecture}.tar.gz"
+    $download_location = "https://storage.googleapis.com/golang/go${version}.${arch}.tar.gz"
   }
 
   Exec {


### PR DESCRIPTION
Without this I was always getting storage.googleapis.com/golang/go1.3.**linux-x86_64**.tar.gz which besides being wrong doesn't exist.
