### PR TITLE
Introducing download timeout for slow connections

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,7 @@ class golang (
   $arch         = 'linux-amd64',
   $download_dir = '/usr/local/src',
   $download_url = undef,
+  $download_timeout = 900,
 ) {
 
   if ($download_url) {
@@ -42,6 +43,7 @@ class golang (
     creates => "${download_dir}/go-${version}.tar.gz",
     unless  => "which go && go version | grep '${version}'",
     require => Package['curl'],
+    timeout => ${download_timeout},
   } ->
   exec { 'unarchive':
     command => "tar -C /usr/local -xzf ${download_dir}/go-${version}.tar.gz && rm ${download_dir}/go-${version}.tar.gz",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,7 +43,7 @@ class golang (
     creates => "${download_dir}/go-${version}.tar.gz",
     unless  => "which go && go version | grep '${version}'",
     require => Package['curl'],
-    timeout => ${download_timeout},
+    timeout => $download_timeout,
   } ->
   exec { 'unarchive':
     command => "tar -C /usr/local -xzf ${download_dir}/go-${version}.tar.gz && rm ${download_dir}/go-${version}.tar.gz",


### PR DESCRIPTION
With some connections the default timeout for `puppet exec` (300 sec) is not enough. 
This variable gives the possibility to avoid errors that may be produced by slow connections. 