### PR TITLE
Use `ensure_packages()` to avoid resource conflicts

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,9 +1,0 @@
-name    'dcoxall-golang'
-version '1.1.1'
-source 'https://github.com/FreakyDazio/dcoxall-golang'
-author 'Darren Coxall'
-license 'MIT'
-
-summary 'A barebones Go installation'
-description 'A barebones Go installation'
-project_page 'https://github.com/FreakyDazio/dcoxall-golang'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,13 +30,12 @@ class golang (
     path => '/usr/local/go/bin:/usr/local/bin:/usr/bin:/bin',
   }
 
-  if ! defined(Package['curl']) {
-    package { 'curl': }
-  }
+  $package_prereqs = [
+    'curl',
+    'mercurial',
+  ]
 
-  if ! defined(Package['mercurial']) {
-    package { 'mercurial': }
-  }
+  ensure_packages($package_prereqs)
 
   exec { 'download':
     command => "curl -o ${download_dir}/go-${version}.tar.gz ${download_location}",

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "dcoxall-golang",
+  "version": "1.1.1",
+  "author": "Darren Coxall",
+  "license": "MIT",
+  "summary": "A barebones Go installation",
+  "source": "https://github.com/dcoxall/dcoxall-golang",
+  "dependencies": [
+    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.1.0 < 5.0.0" }
+  ]
+}

--- a/tests/curl_conflict.pp
+++ b/tests/curl_conflict.pp
@@ -1,0 +1,3 @@
+package { 'curl': ensure => 'present' } ->
+
+class { 'golang': }


### PR DESCRIPTION
This module uses an older technique to make sure that `curl` and
`mercurial` are installed; unfortunately, this technique causes a
resource conflict in the event that either of those package resources
are declared elsewhere.  This patch declares a dependency on
`puppetlabs/stdlib` and then uses the `ensure_packages()` function to
achieve the same effect without the resource conflict.